### PR TITLE
Switch to PyPDF2

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,7 +13,7 @@ In order to install c3bottles, you will need:
 
 *   CairoSVG (python-cairosvg)
 
-*   PyPDF (python-pypdf)
+*   PyPDF2 (python-pypdf2)
 
 *   Python-QRCode (python-qrcode)
 
@@ -37,7 +37,7 @@ In order to install c3bottles, you will need:
 
         $ apt-get install python-flask python-flask-sqlalchemy \
                           python-flask-login python-flaskext.wtf \
-                          python-cairosvg python-pypdf python-qrcode \
+                          python-cairosvg python-pypdf2 python-qrcode \
                           libapache2-mod-wsgi imagemagick \
                           gdal-bin python-gdal npm nodejs-legacy
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ Flask-SQLAlchemy>=2.1
 Flask-Login>=0.4.0
 Flask-WTF>=0.14
 CairoSVG>=1.0.22, <2.0
-pyPdf>=1.13
+pyPDF2>=1.23
 qrcode>=5.3

--- a/view/main.py
+++ b/view/main.py
@@ -78,7 +78,7 @@ def dp_label(number=None):
 @c3bottles.route("/label/all.pdf")
 def dp_all_labels():
     from StringIO import StringIO
-    from pyPdf import PdfFileReader, PdfFileWriter
+    from PyPDF2 import PdfFileWriter, PdfFileReader
     output = PdfFileWriter()
     for dp in db.session.query(DropPoint).all():
         if not dp.removed:


### PR DESCRIPTION
pyPdf is no longer maintained, the fork PyPDF2 is the drop-in
replacement fork which has the blessing of the original author.

See http://pybrary.net/pyPdf/