### PR TITLE
model: Add missing babel import

### DIFF
--- a/model/report.py
+++ b/model/report.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+from flask_babel import lazy_gettext as _
+
 from controller import db
 import model.drop_point
 


### PR DESCRIPTION
Fixes a failing test which reports _() is undefined.

I'm not sure how to fix the other tests, since the exception contains a lazy evaluated string. Which actually doesn't seem to work well. Since the exception string is:

```
{'number': <flask_babel.speaklater.LazyString object at 0x7efc06f3cc50>}
```

So maybe that should be changed to a non lazystring exception?