### PR TITLE
more portable way to call python. Especially in virtual envs.

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from argparse import ArgumentParser
 from werkzeug.contrib.profiler import ProfilerMiddleware


### PR DESCRIPTION
Using env is more friendly in python virtualenv since the interpreter will be chosen from the environment variables and is not hard coded.