### PR TITLE
Make OSM map configurable in config.py

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -93,16 +93,12 @@ it is useful to use a map source already present, namely OpenStreetMap. These
 two ways are described below in the "Internal map" and "OpenStreetMap" sections,
 respectively.
 
-*Attention:* No map source is defined by default! Please have a look in
-`js/map.js`. This file contains the definition for the two map sources.
-Just uncomment the one you want to use.
-
 ## Internal map
 
-To be able to use the internal map, in addition to uncommenting it in `map.js`,
-you first have to generate the map tiles. The normal build task already does
-that with the map delivered with the package. If you replaced the map and just
-want to regenerate the tiles using the defaults, you can do this with:
+The internal map is the default when checking out c3bottles. To use the map you
+first have to generate the map tiles. The normal build task already does that
+with the map delivered with the package. If you replaced the map and just want
+to regenerate the tiles using the defaults, you can do this with:
 
     $ npm run build:map
 
@@ -131,6 +127,6 @@ generate the tiles as follows:
 
 ## OpenStreetMap
 
-OpenStreetMap works out of the box once you have uncommented it in `map.js`.
+OpenStreetMap works out of the box once OSM\_MAP is set to True in config.py.
 Although, for it to be useful, you should set the appropriate event location
 coordinates and a useful zoom level as default view in `map.js`.

--- a/config.default.py
+++ b/config.default.py
@@ -33,4 +33,7 @@
 # no reports have been submitted. (default: 1)
 # DEFAULT_VISIT_PRIORITY = 1
 
+# Use the OSM Map or use the standard tiles map.
+OSM_MAP = False
+
 # vim: set expandtab ts=4 sw=4:

--- a/js/map.js
+++ b/js/map.js
@@ -7,7 +7,7 @@ var L = require("leaflet");
  *
  */
 global.map = undefined;
-global.init_map = function() {
+global.init_map = function(osm_map) {
     map = L.map('map', {
         // set this to true when using Openstreetmap
         // what you set here when you are using another
@@ -16,30 +16,30 @@ global.init_map = function() {
         attributionControl: true
     });
 
-    /* Uncomment this to add the static tile layer */
-    /*L.tileLayer(imgdir + '/tiles/{z}/{x}/{y}.png', {
-        // Have a look in static/img/tiles.
-        // The directories present there correspond to zoom levels.
-        minZoom: 0,
-        maxZoom: 6,
-        tms: true,
-        noWrap: true
-    }).addTo(map);
-    global.default_map_view = function() {
-        map.fitWorld();
-    };*/
-
-    /* Uncomment this to add the Openstreetmap layer for outdoor events */
-    /*L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-        attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
-        subdomains: ['a', 'b', 'c'],
-        minZoom: 15, // this is a reasonable default for a decent outdoor event
-        maxZoom: 18  // this is the maximum zoom level
-    }).addTo(map);
-    global.default_map_view = function() {
-        // set your event coordinates (latitude, longitude, default zoom) here
-        map.setView([53.56164, 9.98550], 17);
-    };*/
+    if (osm_map) {
+        L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: 'Map data © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors',
+            subdomains: ['a', 'b', 'c'],
+            minZoom: 15, // this is a reasonable default for a decent outdoor event
+            maxZoom: 18  // this is the maximum zoom level
+        }).addTo(map);
+        global.default_map_view = function() {
+            // set your event coordinates (latitude, longitude, default zoom) here
+            map.setView([53.56164, 9.98550], 17);
+        };
+    } else {
+        L.tileLayer(imgdir + '/tiles/{z}/{x}/{y}.png', {
+            // Have a look in static/img/tiles.
+            // The directories present there correspond to zoom levels.
+            minZoom: 0,
+            maxZoom: 6,
+            tms: true,
+            noWrap: true
+        }).addTo(map);
+        global.default_map_view = function() {
+            map.fitWorld();
+        };
+    }
 
     for (var i in drop_points) {
         if (!drop_points[i].removed) {

--- a/templates/edit_dp.html
+++ b/templates/edit_dp.html
@@ -100,7 +100,7 @@
 {% include "dp_js.html" %}
 <script type="text/javascript">
     var imgdir = "{{ url_for('static', filename='img') }}";
-    init_map();
+    init_map({{ config.get("OSM_MAP", False)|string|lower }})
     init_dp_creation();
     var lat = {{ lat }};
     var lng = {{ lng }};

--- a/templates/map.html
+++ b/templates/map.html
@@ -18,7 +18,7 @@
 <script type="text/javascript">
     var create_dp_url = "{{ url_for("create_dp") }}";
     var imgdir = "{{ url_for('static', filename='img') }}";
-    init_map();
+    init_map({{ config.get("OSM_MAP", False)|string|lower }})
     var hash = location.hash.substr(1).split("/");
     if (hash.length == 3) {
         map.setView([hash[0], hash[1]], hash[2]);

--- a/templates/view.html
+++ b/templates/view.html
@@ -80,7 +80,7 @@
 {% include "dp_js.html" %}
 <script type="text/javascript">
     var imgdir = "{{ url_for('static', filename='img') }}";
-    init_map();
+    init_map({{ config.get("OSM_MAP", False)|string|lower }})
     map.setView([{{ dp.get_current_location().lat }}, {{ dp.get_current_location().lng }}], 5);
 </script>
 {% endblock %}


### PR DESCRIPTION
The default map is broken, unless an option is uncommented in js/map.js.
Making it configurable makes the map work out of the box and
configurable.